### PR TITLE
Pass request.user to LTI XBlock in Studio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='tahoe-lti',
-    version='0.1.0',
+    version='0.2.0',
     description='Tahoe LTI Customizations package.',
     packages=[
         'tahoe_lti',

--- a/tahoe_lti/xblock_helpers.py
+++ b/tahoe_lti/xblock_helpers.py
@@ -1,0 +1,24 @@
+"""
+Helpers to access the XBlock Runtime modules.
+"""
+
+
+def get_xblock_user(xblock):
+    """
+    Gets the current request user for an XBlock instance.
+
+    :param xblock: XBlock instance.
+    :return: User or None.
+    """
+    from django.contrib.auth import get_user_model
+    user_model = get_user_model()
+
+    try:
+        user_id = xblock.runtime.user_id
+    except AttributeError:
+        return
+
+    try:
+        return user_model.objects.get(pk=user_id)
+    except user_model.DoesNotExist:
+        pass


### PR DESCRIPTION
By using runtime.user_id instead of the LMS-specific runtime.get_real_user. This way both LMS and Studio will send the `lis_person_contact_email_primary` parameter` consistently.

<kbd>![image](https://user-images.githubusercontent.com/645156/78692291-51f30d00-7902-11ea-96ba-9d57f09a6a9b.png)</kbd>

Jira: [**RED-854:** Add support for LTI processors in Studio](https://appsembler.atlassian.net/browse/RED-854)