### PR TITLE
Import error on python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.idea/
 
 # Spyder project settings
 .spyderproject

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install the pip package:
 $ pip install git+https://github.com/appsembler/tahoe-lti.git
 ```
 
-For `Juniper` Add the following settings to your `lms.yml`:
+Add the following settings to your `server-vars.yml` (or whatever method you configure your Open edX installation):
 
 ```yaml
 EDXAPP_XBLOCK_SETTINGS:
@@ -24,10 +24,9 @@ EDXAPP_XBLOCK_SETTINGS:
       - 'tahoe_lti.processors:team_info'
 ```
 
+`Note:` For edX installations prior to `Juniper`, it should be in `json` format
 
-For `ironwood` Add the following settings to your `lms.env.json`:
-
-```yaml
+```.json
 "XBLOCK_SETTINGS" : {
     "lti_consumer": {
         "parameter_processors": [

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install the pip package:
 $ pip install git+https://github.com/appsembler/tahoe-lti.git
 ```
 
-Add the following settings to your `server-vars.yml` (or whatever method you configure your Open edX installation):
+For `Juniper` Add the following settings to your `lms.yml`:
 
 ```yaml
 EDXAPP_XBLOCK_SETTINGS:
@@ -22,6 +22,22 @@ EDXAPP_XBLOCK_SETTINGS:
       - 'tahoe_lti.processors:personal_user_info'
       - 'tahoe_lti.processors:cohort_info'
       - 'tahoe_lti.processors:team_info'
+```
+
+
+For `ironwood` Add the following settings to your `lms.env.json`:
+
+```yaml
+"XBLOCK_SETTINGS" : {
+    "lti_consumer": {
+        "parameter_processors": [
+            "tahoe_lti.processors:basic_user_info",
+            "tahoe_lti.processors:personal_user_info",
+            "tahoe_lti.processors:cohort_info",
+            "tahoe_lti.processors:team_info"
+        ]
+    }
+}
 ```
 
 **Legal Notice:** Both ``basic_user_info`` and ``personal_user_info`` sends personal user information to potential 3rd-party LTI providers.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='tahoe-lti',
-    version='0.2.0',
+    version='0.2.2',
     description='Tahoe LTI Customizations package.',
     packages=[
         'tahoe_lti',

--- a/tahoe_lti/processors.py
+++ b/tahoe_lti/processors.py
@@ -1,7 +1,7 @@
 """
 Common LTI processors for Tahoe.
 """
-from xblock_helpers import get_xblock_user
+from tahoe_lti.xblock_helpers import get_xblock_user
 
 
 def basic_user_info(xblock):


### PR DESCRIPTION
### Import error on python3

Fixed import error on python3 
`from xblock_helpers import get_xblock_user` fails in venv of python3
Updated `readME` for different edX installations.