### PR TITLE
[SE-4345] feat: add alternate custom_user_id generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- added alternative `custom_user_id` generation
+
 ### Changed
 ### Removed
 
@@ -25,6 +28,7 @@ release before changelog was added.
 
 release before changelog was added.
 
-[Unreleased]: https://github.com/appsembler/tahoe-lti/compare/release-0.2.0...HEAD
+[Unreleased]: https://github.com/appsembler/tahoe-lti/compare/release-0.3.0...HEAD
+[0.3.0]: https://github.com/appsembler/tahoe-lti/releases/compare/release-0.2.0..release-0.3.0
 [0.2.0]: https://github.com/appsembler/tahoe-lti/releases/compare/release-0.1.0..release-0.2.0
 [0.1.0]: https://github.com/appsembler/tahoe-lti/releases/tag/release-0.1.0

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ EDXAPP_XBLOCK_SETTINGS:
 **Legal Notice:** Both ``basic_user_info`` and ``personal_user_info`` sends personal user information to potential 3rd-party LTI providers.
 Please make sure that this is reflected on the Privacy Policy of the site.
 
+In case the same LTI configuration used for multiple edX installations, alternatively you may want to replace `personal_user_info` processor by `combined_email_based_personal_user_info`. The `combined_email_based_personal_user_info` processor does exactly the same what `personal_user_info`, but using the hash of the user's email address and join date ensuring that the user can have the same email address across edX installations.
 
 Restart the Open edX instance and it should be working.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ EDXAPP_XBLOCK_SETTINGS:
 **Legal Notice:** Both ``basic_user_info`` and ``personal_user_info`` sends personal user information to potential 3rd-party LTI providers.
 Please make sure that this is reflected on the Privacy Policy of the site.
 
-In case the same LTI configuration used for multiple edX installations, alternatively you may want to replace `personal_user_info` processor by `combined_email_based_personal_user_info`. The `combined_email_based_personal_user_info` processor does exactly the same what `personal_user_info`, but using the hash of the user's email address and join date ensuring that the user can have the same email address across edX installations.
+In case the same LTI configuration used for multiple edX installations, alternatively you may want to replace `personal_user_info` processor by `personal_user_info_with_combined_user_id`. The `personal_user_info_with_combined_user_id` processor does exactly the same what `personal_user_info`, but using the hash of the user's email address and join date ensuring that the user can have the same email address across edX installations.
 
 Restart the Open edX instance and it should be working.
 

--- a/tahoe_lti/processors.py
+++ b/tahoe_lti/processors.py
@@ -3,7 +3,6 @@ Common LTI processors for Tahoe.
 """
 
 import json
-import hashlib
 from django.conf import settings
 
 from .xblock_helpers import get_xblock_user

--- a/tahoe_lti/processors.py
+++ b/tahoe_lti/processors.py
@@ -45,7 +45,6 @@ class PersonalUserInfoProcessor(object):
             date_joined=date_joined
         ).encode())
 
-
         return user_hash.hexdigest()
 
     def personal_user_info(self, xblock):
@@ -60,7 +59,6 @@ class PersonalUserInfoProcessor(object):
             user_id = self.__get_combined_user_email(user)
         else:
             user_id = str(user.id)
-
 
         user_full_name = user.profile.name
         names_list = user_full_name.split(' ', 1)
@@ -182,28 +180,3 @@ def window_document_target(xblock):
 window_document_target.lti_xblock_default_params = {
     'launch_presentation_document_target': 'window',
 }
-
-
-def combined_user_email_as_custom_user_id(user):
-    """
-    Compose a user identification string from user email and join date.
-
-    In rare cases `user.id` cannot be used with LTI providers when the user id
-    already exists on the provider side. To support scenarios like this, it is
-    needed to have another way to generate a user identification string that
-    is unique per user per installation.
-
-    To provide a per-instance unique string for the user, we return the hashed
-    combination of the user's email and registration date.
-    """
-
-    date_joined = str(user.date_joined.timestamp())
-
-    user_hash = hashlib.sha1("{user_email}-{date_joined}".format(
-        user_email=user.email,
-        date_joined=date_joined
-    ).encode())
-
-
-
-    return user_hash.hexdigest()

--- a/tahoe_lti/processors.py
+++ b/tahoe_lti/processors.py
@@ -21,31 +21,30 @@ class PersonalUserInfoProcessor(object):
         'custom_user_id': '',
     }
 
-    def __init__(self, use_combined_email_as_id=False):
+    def __init__(self, use_combined_id=False):
         super(PersonalUserInfoProcessor, self).__init__()
-        self.use_combined_email_as_id = use_combined_email_as_id
+        self.use_combined_id = use_combined_id
 
-    def __get_combined_user_email(self, user):
+    @staticmethod
+    def __get_combined_user_id(user):
         """
-        Compose a user identification string from user email and join date.
+        Compose a user identification string from user id and join date.
 
         In rare cases `user.id` cannot be used with LTI providers when the user id
         already exists on the provider side. To support scenarios like this, it is
         needed to have another way to generate a user identification string that
         is unique per user per installation.
 
-        To provide a per-instance unique string for the user, we return the hashed
-        combination of the user's email and registration date.i
+        To provide a per-instance unique string for the user, we return the
+        combination of the user's id and registration date.
         """
 
-        date_joined = user.date_joined.isoformat()
+        date_joined = user.date_joined.strftime("%y%m%d%H%M")
 
-        user_hash = hashlib.sha1("{user_email}-{date_joined}".format(
-            user_email=user.email,
+        return "{user_id}-{date_joined}".format(
+            user_id=user.id,
             date_joined=date_joined
-        ).encode())
-
-        return user_hash.hexdigest()
+        )
 
     def personal_user_info(self, xblock):
         """
@@ -53,10 +52,10 @@ class PersonalUserInfoProcessor(object):
         """
         user = get_xblock_user(xblock)
         if not user:
-            return
+            return {}
 
-        if self.use_combined_email_as_id:
-            user_id = self.__get_combined_user_email(user)
+        if self.use_combined_id:
+            user_id = self.__get_combined_user_id(user)
         else:
             user_id = str(user.id)
 
@@ -78,8 +77,8 @@ class PersonalUserInfoProcessor(object):
 
 
 personal_user_info = PersonalUserInfoProcessor().personal_user_info
-combined_email_based_personal_user_info = PersonalUserInfoProcessor(
-    use_combined_email_as_id=True
+personal_user_info_with_combined_user_id = PersonalUserInfoProcessor(
+    use_combined_id=True
 ).personal_user_info
 
 

--- a/tahoe_lti/processors.py
+++ b/tahoe_lti/processors.py
@@ -35,10 +35,10 @@ class PersonalUserInfoProcessor(object):
         is unique per user per installation.
 
         To provide a per-instance unique string for the user, we return the hashed
-        combination of the user's email and registration date.
+        combination of the user's email and registration date.i
         """
 
-        date_joined = str(user.date_joined.timestamp())
+        date_joined = user.date_joined.isoformat()
 
         user_hash = hashlib.sha1("{user_email}-{date_joined}".format(
             user_email=user.email,

--- a/tahoe_lti/processors.py
+++ b/tahoe_lti/processors.py
@@ -94,6 +94,7 @@ def basic_user_info(xblock):
             'lis_person_sourcedid': user.username,
             'lis_person_contact_email_primary': user.email,
         }
+    return {}
 
 
 def cohort_info(xblock):

--- a/tahoe_lti/processors.py
+++ b/tahoe_lti/processors.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from .xblock_helpers import get_xblock_user
 
 
-DEFAULT_PERSONAL_USER_INFO_PARAMS = {
+DEFAULT_USER_INFO_PARAMS = {
     'lis_person_name_full': '',
     'lis_person_name_given': '',
     'lis_person_name_family': '',
@@ -46,7 +46,7 @@ def personal_user_info(xblock):
     return _get_personal_user_info_params(user)
 
 
-personal_user_info.lti_xblock_default_params = DEFAULT_PERSONAL_USER_INFO_PARAMS
+personal_user_info.lti_xblock_default_params = DEFAULT_USER_INFO_PARAMS
 
 
 def personal_user_info_with_combined_user_id(xblock):
@@ -74,7 +74,7 @@ def personal_user_info_with_combined_user_id(xblock):
     return params
 
 
-personal_user_info_with_combined_user_id.lti_xblock_default_params = DEFAULT_PERSONAL_USER_INFO_PARAMS
+personal_user_info_with_combined_user_id.lti_xblock_default_params = DEFAULT_USER_INFO_PARAMS
 
 
 def basic_user_info(xblock):

--- a/tests/test_user_info_processors.py
+++ b/tests/test_user_info_processors.py
@@ -64,7 +64,7 @@ def test_personal_user_info_combined_email_as_user_id(mock_get_xblock_user):
     info = combined_email_based_personal_user_info(xblock=None)
     assert info == {
         # sha1 hash hex digest of the email and join date combination
-        'custom_user_id': '18799c69ff91da68cdb901a9958ae38a7f79dceb',
+        'custom_user_id': 'fa0a961625f6d17bad8d4d1a239b2d4a83a812f0',
         'lis_person_name_full': 'Bob Robot',
         'lis_person_name_given': 'Bob',
         'lis_person_name_family': 'Robot',

--- a/tests/test_user_info_processors.py
+++ b/tests/test_user_info_processors.py
@@ -1,6 +1,11 @@
+from datetime import datetime
 from mock import patch, Mock
 
-from tahoe_lti.processors import basic_user_info, personal_user_info
+from tahoe_lti.processors import (
+    basic_user_info,
+    personal_user_info,
+    combined_email_based_personal_user_info,
+)
 
 
 @patch('tahoe_lti.processors.get_xblock_user')
@@ -34,6 +39,32 @@ def test_personal_user_info(mock_get_xblock_user):
     info = personal_user_info(xblock=None)
     assert info == {
         'custom_user_id': '20',
+        'lis_person_name_full': 'Bob Robot',
+        'lis_person_name_given': 'Bob',
+        'lis_person_name_family': 'Robot',
+    }
+
+
+@patch('tahoe_lti.processors.get_xblock_user')
+def test_personal_user_info_combined_email_as_user_id(mock_get_xblock_user):
+    """Happy scenario for personal_user_info"""
+    assert combined_email_based_personal_user_info.lti_xblock_default_params == {
+        'lis_person_name_full': '',
+        'lis_person_name_given': '',
+        'lis_person_name_family': '',
+        'custom_user_id': '',
+    }
+
+    mock_user = Mock()
+    mock_user.profile.name = 'Bob Robot'
+    mock_user.email = 'bob.robot@example.com'
+    mock_user.date_joined = datetime(1970, 1, 1, 1, 0)
+    mock_get_xblock_user.return_value = mock_user
+
+    info = combined_email_based_personal_user_info(xblock=None)
+    assert info == {
+        # sha1 hash hex digest of the email and join date combination
+        'custom_user_id': '18799c69ff91da68cdb901a9958ae38a7f79dceb',
         'lis_person_name_full': 'Bob Robot',
         'lis_person_name_given': 'Bob',
         'lis_person_name_family': 'Robot',

--- a/tests/test_user_info_processors.py
+++ b/tests/test_user_info_processors.py
@@ -4,7 +4,7 @@ from mock import patch, Mock
 from tahoe_lti.processors import (
     basic_user_info,
     personal_user_info,
-    combined_email_based_personal_user_info,
+    personal_user_info_with_combined_user_id,
 )
 
 
@@ -46,9 +46,9 @@ def test_personal_user_info(mock_get_xblock_user):
 
 
 @patch('tahoe_lti.processors.get_xblock_user')
-def test_personal_user_info_combined_email_as_user_id(mock_get_xblock_user):
+def test_personal_user_info_combined_user_id(mock_get_xblock_user):
     """Happy scenario for personal_user_info"""
-    assert combined_email_based_personal_user_info.lti_xblock_default_params == {
+    assert personal_user_info_with_combined_user_id.lti_xblock_default_params == {
         'lis_person_name_full': '',
         'lis_person_name_given': '',
         'lis_person_name_family': '',
@@ -56,15 +56,15 @@ def test_personal_user_info_combined_email_as_user_id(mock_get_xblock_user):
     }
 
     mock_user = Mock()
+    mock_user.id = 123
     mock_user.profile.name = 'Bob Robot'
-    mock_user.email = 'bob.robot@example.com'
     mock_user.date_joined = datetime(1970, 1, 1, 1, 0)
     mock_get_xblock_user.return_value = mock_user
 
-    info = combined_email_based_personal_user_info(xblock=None)
+    info = personal_user_info_with_combined_user_id(xblock=None)
     assert info == {
         # sha1 hash hex digest of the email and join date combination
-        'custom_user_id': 'fa0a961625f6d17bad8d4d1a239b2d4a83a812f0',
+        'custom_user_id': '123-7001010100',
         'lis_person_name_full': 'Bob Robot',
         'lis_person_name_given': 'Bob',
         'lis_person_name_family': 'Robot',


### PR DESCRIPTION
This PR adds an alternate way to generate `custom_user_id`.

In rare cases `user.id` cannot be used with LTI providers when the user id already exists on the provider side. To support scenarios like this, it is needed to have another way to generate a user identification string that is unique per user per installation. To provide a per-instance unique string for the user, we return the hashed combination of the user's id and registration date.

**Dependencies**: None

**Screenshots**:  N/A

**Sandbox URL**: TBD - the sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

1. login with edx user
2. add an LTI block described in readme test instructions
3. use `personal_user_info_with_combined_user_id` instead of the original personal user info processor
3. check the `custom_user_id` sent to the provider

**Author notes and concerns**:

1. The function naming for alternate id generation may not the best.